### PR TITLE
Include docs in sdist, so that packages can build docs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst LICENSE
+include docs


### PR DESCRIPTION
I went to packages this as an RPM, and tried to build the docs from the sdist, but was unable to.
