### PR TITLE
Don't allow additional kwargs to attributes.

### DIFF
--- a/characteristic.py
+++ b/characteristic.py
@@ -520,14 +520,23 @@ def attributes(attrs, apply_with_cmp=True, apply_with_init=True,
     :param create_init: Apply :func:`with_init`.
     :type create_init: bool
     """
-    if "create_init" in kw:
-        apply_with_init = kw["create_init"]
+
+    create_init = kw.pop("create_init", None)
+    if create_init is not None:
+        apply_with_init = create_init
         warnings.warn(
             "`create_init` has been deprecated in 14.0, please use "
             "`apply_with_init`.", DeprecationWarning,
             stacklevel=2,
         )
-    attrs = _ensure_attributes(attrs, defaults=kw.get("defaults", NOTHING))
+    attrs = _ensure_attributes(attrs, defaults=kw.pop("defaults", NOTHING))
+
+    if kw:
+        raise TypeError(
+            "attributes() got an unexpected keyword argument {0!r}".format(
+                next(iter(kw)),
+            )
+        )
 
     def wrap(cl):
         if apply_with_repr is True:

--- a/test_characteristic.py
+++ b/test_characteristic.py
@@ -614,6 +614,18 @@ class TestAttributes(object):
         ) == w[0].message.args[0]
         assert issubclass(w[0].category, DeprecationWarning)
 
+    def test_does_not_allow_extra_keyword_arguments(self):
+        """
+        Keyword arguments other than the ones consumed are still TypeErrors.
+        """
+        with pytest.raises(TypeError) as e:
+            @attributes(["a"], not_an_arg=12)
+            class C(object):
+                pass
+        assert e.value.args == (
+            "attributes() got an unexpected keyword argument 'not_an_arg'",
+        )
+
 
 class TestEnsureAttributes(object):
     def test_leaves_attribute_alone(self):


### PR DESCRIPTION
Prevent `attributes()` from silently swallowing any kwargs it doesn't understand.
