### PR TITLE
README.rst: Add teaser (with `doctest` lexer)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,34 @@ characteristic: Python attributes without boilerplate.
    :target: https://coveralls.io/r/hynek/characteristic?branch=master
    :alt: Current coverage
 
+
+Teaser
+------
+
+.. code-block:: pycon
+
+   >>> from characteristic import Attribute, attributes
+   >>> @attributes(["a", "b"])
+   ... class AClass(object):
+   ...     pass
+   >>> @attributes(["a", Attribute("b", default_value="abc", instance_of=str)])
+   ... class AnotherClass(object):
+   ...     pass
+   >>> obj1 = AClass(a=1, b="abc")
+   >>> obj2 = AnotherClass(a=1, b="abc")
+   >>> obj3 = AnotherClass(a=1)
+   >>> AnotherClass(a=1, b=42)
+   Traceback (most recent call last):
+    ...
+   TypeError: Attribute 'b' must be an instance of 'str'.
+   >>> print obj1, obj2, obj3
+   <AClass(a=1, b='abc')> <AnotherClass(a=1, b='abc')> <AnotherClass(a=1, b='abc')>
+   >>> obj1 == obj2
+   False
+   >>> obj2 == obj3
+   True
+
+
 .. begin
 
 


### PR DESCRIPTION
Because a teaser on the [PyPI page](https://pypi.python.org/pypi/characteristic/) is nice and changing the lexer from `doctest` to `pycon` will allow it to render in nice color on PyPI (and in the future on GitHub, when https://github.com/github/linguist/issues/1939 gets deployed).

```
[marca@marca-mac2 characteristic]$ pygmentize -L | egrep 'doctest|pycon'
* pycon:
```

Preview at https://github.com/msabramo/characteristic/tree/README_teaser

Preview of how it will look on GitHub when they deploy https://github.com/github/linguist/issues/1939 to production: [lightshow](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-text&grammar_url=&grammar_text=%27scopeName%27%3A+%27text.python.console%27%0D%0A%27name%27%3A+%27Python+Console%27%0D%0A%27fileTypes%27%3A+%5B%0D%0A++%27pycon%27%0D%0A%5D%0D%0A%27patterns%27%3A+%5B%0D%0A++%7B%0D%0A++++%27match%27%3A+%27%5E%28%3E%7B3%7D%7C%5C%5C.%7B3%7D%7CIn+%5C%5C%5B%5C%5Cd%2B%5C%5C%5D%3A%29+%28.%2B%29%24%27%0D%0A++++%27captures%27%3A%0D%0A++++++%271%27%3A%0D%0A++++++++%27name%27%3A+%27punctuation.separator.prompt.python-session%27%0D%0A++++++%272%27%3A%0D%0A++++++++%27patterns%27%3A+%5B%0D%0A++++++++++%27include%27%3A+%27source.python%27%0D%0A++++++++%5D%0D%0A++%7D%0D%0A%5D&code_source=from-text&code_url=&code=%3E%3E%3E+from+characteristic+import+Attribute%2C+attributes%0D%0A%3E%3E%3E+%40attributes%28%5B%22a%22%2C+%22b%22%5D%29%0D%0A...+class+AClass%28object%29%3A%0D%0A...+++++pass%0D%0A%3E%3E%3E+%40attributes%28%5B%22a%22%2C+Attribute%28%22b%22%2C+default_value%3D%22abc%22%2C+instance_of%3Dstr%29%5D%29%0D%0A...+class+AnotherClass%28object%29%3A%0D%0A...+++++pass%0D%0A%3E%3E%3E+obj1+%3D+AClass%28a%3D1%2C+b%3D%22abc%22%29%0D%0A%3E%3E%3E+obj2+%3D+AnotherClass%28a%3D1%2C+b%3D%22abc%22%29%0D%0A%3E%3E%3E+obj3+%3D+AnotherClass%28a%3D1%29%0D%0A%3E%3E%3E+AnotherClass%28a%3D1%2C+b%3D42%29%0D%0ATraceback+%28most+recent+call+last%29%3A%0D%0A+...%0D%0ATypeError%3A+Attribute+%27b%27+must+be+an+instance+of+%27str%27.%0D%0A%3E%3E%3E+print+obj1%2C+obj2%2C+obj3%0D%0A%3CAClass%28a%3D1%2C+b%3D%27abc%27%29%3E+%3CAnotherClass%28a%3D1%2C+b%3D%27abc%27%29%3E+%3CAnotherClass%28a%3D1%2C+b%3D%27abc%27%29%3E%0D%0A%3E%3E%3E+obj1+%3D%3D+obj2%0D%0AFalse%0D%0A%3E%3E%3E+obj2+%3D%3D+obj3%0D%0ATrue)
