### PR TITLE
Tiny documentation fix, duplicated attribute name in why.rst

### DIFF
--- a/docs/why.rst
+++ b/docs/why.rst
@@ -13,7 +13,7 @@ Readability
 
 What makes more sense while debugging::
 
-   <Point(x=1, x=2)>
+   <Point(x=1, y=2)>
 
 or::
 


### PR DESCRIPTION
Change duplicated x point attribute names to x and y.